### PR TITLE
[SECURITY] Harden GitHub workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       all:
         dependency-type: "production"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
   schedule:
   - cron: "0 4 * * *"
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -14,7 +16,7 @@ jobs:
     name: Build Landscape
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write # Required to commit and push the built landscape data
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,15 +5,22 @@ on:
   schedule:
   - cron: "0 4 * * *"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    name: Build Landscape
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: audit
-      - uses: jmertic/lfx-landscape-tools@main
+      - uses: jmertic/lfx-landscape-tools@a6d97ddd4871979055662697cd84cfb32b1bcc98 # main
         with:
           project_processing: skip
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: audit
-      - uses: jmertic/lfx-landscape-tools@a6d97ddd4871979055662697cd84cfb32b1bcc98 # main
+      - uses: jmertic/lfx-landscape-tools@29c3da5bc185f8b7118c50607bf4d58b8b73c0e4 # 20260331
         with:
           project_processing: skip
         env:

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -4,30 +4,38 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-permissions:
-  contents: write
-  pull-requests: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   dependabot:
+    name: Dependabot Auto-merge
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    permissions:
+      contents: write # Required to merge Dependabot PRs
+      pull-requests: write # Required to approve Dependabot PRs
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        
+        with:
+          persist-credentials: false
+
       - name: Approve PR
         run: |
-          gh pr review --approve "${{ github.event.pull_request.number }}"
+          gh pr review --approve "$PR_NUMBER"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
 
       - name: Enable auto-merge
         run: |
           gh pr merge \
             --squash \
             --auto \
-            "${{ github.event.pull_request.number }}"
+            "$PR_NUMBER"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,8 +1,5 @@
 name: Preview
 
-permissions:
-  pull-requests: write
-
 on:
   pull_request:
     branches:
@@ -14,9 +11,16 @@ on:
     types:
       - opened
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   comment:
+    name: Post Preview Comment
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # Required to post a preview link comment on pull requests
     steps:
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -11,6 +11,8 @@ on:
     types:
       - opened
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,12 +6,20 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate-landscape:
     runs-on: ubuntu-latest
     name: "Validate landscape.yml file"
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: cncf/landscape2-validate-action@6381e8747c73412e638670807b402ef2b863e9f8 # v2.0.1
         with:
           target_kind: data


### PR DESCRIPTION
## Changes

This pull request fixes all outstanding issues that the [zizmor 🌈](https://github.com/zizmorcore/zizmor) static analysis analyzer has found. Tackling these helps protect us against supply chain exploits, GitHub exploits, and more.

Going forward, this will be enforced by the new [`OMF Security Checks`](https://github.com/OvertureMaps/overture-tiles/actions/runs/24087054486?pr=66) workflow that will be enabled in this repo (and many more) via Org ruleset, which runs the GitHub Action version of zizmor (see checks below!)