### PR TITLE
[CHORE] Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,4 @@
 # Default owners for everything in the repo
 * @jmertic, @dwoolflf
+
+/.github @overturemaps/omf-public-reviewers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # Default owners for everything in the repo
-* @jmertic, @dwoolflf
+* @jmertic @dwoolflf
 
 /.github @overturemaps/omf-public-reviewers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything in the repo
+* @jmertic, @dwoolflf


### PR DESCRIPTION
Adds a CODEOWNERS file, so we can enable branch rulesets to require at least one CODEOWNER review to allow automated landscape PRs to auto-merge as a safety gate.

## Behavior Post Merge

1. Automated updates to `landscape.yml` are done via PR
2. Once approved by @jmertic or @dwoolflf, the PR should auto-merge